### PR TITLE
Updated parent/root version for LoggingPlugin because it was outdated a...

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.strategicgains.plugin-express</groupId>
 		<artifactId>PluginExpress-Parent</artifactId>
-		<version>0.2.6-SNAPSHOT</version>
+		<version>0.2.7-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
...nd not in sync.  This caused a compile error because the previous version of PluginParent 0.2.6-SNAPSHOT referred to an older SNAPSHOT version of RestExpress that is not currently available (0.10.5-SNAPShOT RestExpress).
